### PR TITLE
Support Latest Content Search Autocomplete

### DIFF
--- a/app/assets/stylesheets/workarea/storefront/components/_haven_content_search_autocomplete.scss
+++ b/app/assets/stylesheets/workarea/storefront/components/_haven_content_search_autocomplete.scss
@@ -6,9 +6,14 @@
 $search-autocomplete-content-link-color: $white !default;
 
 .search-autocomplete__content {
-    @extend %list-reset;
+    @include respond-to($medium-breakpoint) {
+        text-align: left;
+    }
 }
-    .search-autocomplete__content-item {}
+
+    .search-autocomplete__content-item {
+        color: $search-autocomplete-content-link-color;
+    }
 
         .search-autocomplete__content-link {
             color: $search-autocomplete-content-link-color;

--- a/app/assets/stylesheets/workarea/storefront/search_autocomplete/components/_search_autocomplete.scss
+++ b/app/assets/stylesheets/workarea/storefront/search_autocomplete/components/_search_autocomplete.scss
@@ -40,10 +40,11 @@ $search-autocomplete-z-indexes: ();
     }
 
 
-    .search-autocomplete__searches {
-        @extend %list-reset;
-    }
+    .search-autocomplete__searches {}
 
+        .search-autocomplete__searches-list {
+            @extend %list-reset;
+        }
         .search-autocomplete__searches-item {}
 
             .search-autocomplete__searches-link {

--- a/app/views/workarea/storefront/searches/autocomplete.html.haml
+++ b/app/views/workarea/storefront/searches/autocomplete.html.haml
@@ -1,16 +1,17 @@
 .grid
   .grid__cell.grid__cell--25
     - if @autocomplete.searches.any?
-      %span.search-autocomplete__heading
-        - if @autocomplete.trending_searches?
-          = t('workarea.storefront.search_autocomplete.trending_searches')
-        - else
-          = t('workarea.storefront.search_autocomplete.popular_searches')
+      .search-autocomplete__searches
+        %span.search-autocomplete__heading
+          - if @autocomplete.trending_searches?
+            = t('workarea.storefront.search_autocomplete.trending_searches')
+          - else
+            = t('workarea.storefront.search_autocomplete.popular_searches')
 
-      %ul.search-autocomplete__searches
-        - @autocomplete.searches.each do |search|
-          %li.search-autocomplete__searches-item
-            = link_to search, search_path(q: search), class: 'search-autocomplete__searches-link'
+        %ul.search-autocomplete__searches-list
+          - @autocomplete.searches.each do |search|
+            %li.search-autocomplete__searches-item
+              = link_to search, search_path(q: search), class: 'search-autocomplete__searches-link'
 
     = append_partials('storefront.search_autocomplete_under_searches')
 

--- a/config/initializers/appends.rb
+++ b/config/initializers/appends.rb
@@ -23,7 +23,8 @@ module Workarea
     "workarea/storefront/components/product_media",
     "workarea/storefront/components/recommendations",
     "workarea/storefront/components/quantity_control",
-    "workarea/storefront/components/search"
+    "workarea/storefront/components/search",
+    "workarea/storefront/components/haven_content_search_autocomplete"
   )
 
   Plugin.append_stylesheets(


### PR DESCRIPTION
This removes a `%list-reset` extension on an element that is no longer a `<ul>`. The content list element in the plugin will now have list-reset baked in, so no need to add it here.